### PR TITLE
Add binary path to resolve buildpack test error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ unstable = []
 
 [[bin]]
 name = "hello"
+path = "src/hello.rs"
 
 [dependencies]
 iron = "0.4.0"


### PR DESCRIPTION
While testing my changes to the heroku buildpack, I got a warning:

```
testbuild_1  | warning: path `/src/heroku-rust-cargo-hello/src/hello.rs` was erroneously implicitly accepted for binary `hello`,
testbuild_1  | please set bin.path in Cargo.toml
```

This change resolved that.